### PR TITLE
Update Akka.TestKit.NUnit to NUnit v4 (renewed)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
-## [1.5.0] / March 3 2023
-- [Bump Akka.NET to 1.5.0](https://github.com/akkadotnet/akka.net/releases/tag/1.5.0)
-- [Bump NUnit3TestAdapter to 4.3.1](https://github.com/akkadotnet/Akka.TestKit.NUnit/commit/591892dd6383c94bcf7c2ef7974cf1ce02165092)
+## [1.5.24] / June 11 2024
+ - [Bump Akka.TestKit to 1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
+ - [Bump NUnit3TestAdapter to 4.5.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/97)
+ - [Bump NUnit to 3.14.0](https://github.com/akkadotnet/Akka.TestKit.NUnit/pull/116)
 
 ## [1.4.39] / July 22 2022
  - Support for Akka 1.4.39

--- a/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
+++ b/src/Akka.TestKit.NUnit.Tests/Akka.TestKit.NUnit.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
   </ItemGroup>

--- a/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
+++ b/src/Akka.TestKit.NUnit3.Tests/Akka.TestKit.NUnit3.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
     <PackageReference Include="NUnit3TestAdapter" Version="$(NUnitAdapterVersion)" />
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,6 @@
 	<PropertyGroup>
 		<NUnitVersion>3.14.0</NUnitVersion>
 		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
-		<AkkaTestKitVersion>1.5.25</AkkaTestKitVersion>
+		<AkkaTestKitVersion>1.5.26</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,6 @@
 	<PropertyGroup>
 		<NUnitVersion>3.14.0</NUnitVersion>
 		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
-		<AkkaTestKitVersion>1.5.22</AkkaTestKitVersion>
+		<AkkaTestKitVersion>1.5.24</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,7 @@
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
 	</PropertyGroup>
 	<PropertyGroup>
-		<NUnitVersion>3.13.3</NUnitVersion>
+		<NUnitVersion>3.14.0</NUnitVersion>
 		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
 		<AkkaTestKitVersion>1.5.22</AkkaTestKitVersion>
 	</PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,6 @@
 	<PropertyGroup>
 		<NUnitVersion>3.13.3</NUnitVersion>
 		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
-		<AkkaTestKitVersion>1.5.7</AkkaTestKitVersion>
+		<AkkaTestKitVersion>1.5.20</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,6 @@
 	<PropertyGroup>
 		<NUnitVersion>3.13.3</NUnitVersion>
 		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
-		<AkkaTestKitVersion>1.5.20</AkkaTestKitVersion>
+		<AkkaTestKitVersion>1.5.22</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,6 @@
 	<PropertyGroup>
 		<NUnitVersion>3.14.0</NUnitVersion>
 		<NUnitAdapterVersion>4.5.0</NUnitAdapterVersion>
-		<AkkaTestKitVersion>1.5.24</AkkaTestKitVersion>
+		<AkkaTestKitVersion>1.5.25</AkkaTestKitVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
This builds upon the work of @SeanKilleen in #112. On top of #112 it adds .NET Framework 4.6.2 as an additional target framework (as NUnit 4 dropped netstandard 2.0 support in favour of supporting both .NET standard 6 and .NET Framework 4.6.2, cf. [breaking changes of NUnit 4](https://docs.nunit.org/articles/nunit/release-notes/breaking-changes.html)).

Fixes #111